### PR TITLE
Fixes Android error "illegal start of type"

### DIFF
--- a/android/src/main/java/com/chirag/RNMail/RNMail.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMail.java
@@ -16,7 +16,7 @@ public class RNMail implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(
                               ReactApplicationContext reactContext) {
-    List<NativeModule> modules = new ArrayList<>();
+    List<NativeModule> modules = new ArrayList<NativeModule>();
 
     modules.add(new RNMailModule(reactContext));
 


### PR DESCRIPTION
Fixes Android compilation error:

```
:RNMail:processReleaseJavaRes UP-TO-DATE
:RNMail:compileReleaseJavaWithJavac
/path/to/project/node_modules/react-native-mail/android/src/main/java/com/chirag/RNMail/RNMail.java:19: illegal start of type
    List<NativeModule> modules = new ArrayList<>();
                                               ^
1 error
:RNMail:compileReleaseJavaWithJavac FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':RNMail:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```