### PR TITLE
- Attachments on Android working (with a change to parameter attachment)

### DIFF
--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -3,6 +3,7 @@ package com.chirag.RNMail;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.net.Uri;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -52,6 +53,12 @@ public class RNMailModule extends ReactContextBaseJavaModule {
         recipients[keyIndex] = r.getString(keyIndex);
       }
       i.putExtra(Intent.EXTRA_EMAIL, recipients);
+    }
+
+    if (options.hasKey("attachment") && !options.isNull("attachment")) {
+      ReadableArray r = options.getArray("attachment");
+        Uri uri = Uri.parse(r.getString(0));
+      i.putExtra(Intent.EXTRA_STREAM, uri);
     }
 
     PackageManager manager = reactContext.getPackageManager();


### PR DESCRIPTION
Hi, I added the necessary support.
BUT, the argument attachment needs to be array, not an object.
IE: attachment: [source.uri],
and not
attachment: {
path: source,  // The absolute path of the file from which to
read data.
type: source.uri.substr(source.uri.lastIndexOf('.') + 1),
// Mime Type: jpg, png, doc, ppt, html, pdf
name: '',   // Optional: Custom filename for attachment
}

Maybe you guys can implement the support for object, I have very
limited Android knowledge…