### PR TITLE
Correct way to send Email Intent in Android

### DIFF
--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -3,6 +3,7 @@ package com.chirag.RNMail;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
+import android.net.Uri;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -33,8 +34,8 @@ public class RNMailModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void mail(ReadableMap options, Callback callback) {
-    Intent i = new Intent(Intent.ACTION_SEND);
-    i.setType("message/rfc822");
+    Intent i = new Intent(Intent.ACTION_SENDTO);
+    i.setData(Uri.parse("mailto:"));
 
     if (options.hasKey("subject") && !options.isNull("subject")) {
       i.putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));


### PR DESCRIPTION
Using mimetype will trigger intent to many apps that are not mail client (Snapchat, Skype,... etc)