### PR TITLE
[android] Fix attachments and add option to set custom label for chooser

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ var MailExampleApp = React.createClass({
 ```
 
 ### Note
-On android callback will only have error(if any) as the argument. event is not available on android.
+- If you use attachment on android, file must be located in external storage directory or world readable (unsafe).
+- On android callback will only have error(if any) as the argument. event is not available on android.
 
 ## Here is how it looks:
 ![Demo gif](https://github.com/chirag04/react-native-mail/blob/master/screenshot.jpg)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,8 @@ var MailExampleApp = React.createClass({
         path: '',  // The absolute path of the file from which to read data.
         type: '',   // Mime Type: jpg, png, doc, ppt, html, pdf
         name: '',   // Optional: Custom filename for attachment
-      }
+      },
+      chooserLabel: '' // Android only, the label displayed on chooser
     }, (error, event) => {
         if(error) {
           AlertIOS.alert('Error', 'Could not send mail. Please send a mail to support@example.com');

--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -52,8 +52,14 @@ public class RNMailModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void mail(ReadableMap options, Callback callback) {
-    Intent i = new Intent(Intent.ACTION_SENDTO);
-    i.setData(Uri.parse("mailto:"));
+    Intent i;
+    if (options.hasKey("attachment") && !options.isNull("attachment")) {
+      i = new Intent(Intent.ACTION_SEND);
+      i.setType("vnd.android.cursor.dir/email");
+    } else {
+      i = new Intent(Intent.ACTION_SENDTO);
+      i.setData(Uri.parse("mailto:"));
+    }
 
     if (options.hasKey("subject") && !options.isNull("subject")) {
       i.putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));

--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -104,7 +104,13 @@ public class RNMailModule extends ReactContextBaseJavaModule {
         callback.invoke("error");
       }
     } else {
-      Intent chooser = Intent.createChooser(i, "Send Mail");
+      String chooserLabel;
+      if (options.hasKey("chooserLabel") && !options.isNull("chooserLabel")) {
+       chooserLabel = options.getString("chooserLabel");
+      } else {
+       chooserLabel = "Send Mail";
+      }
+      Intent chooser = Intent.createChooser(i, chooserLabel);
       chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
       try {


### PR DESCRIPTION
When sending mail with attachment correct action is `ACTION_SEND`, with current solution many email clients are ignroing the attachment. Also I've added `chooserLabel` option so people can specify their own title for chooser (localized etc..). Both changes have been tested on device and I am successfuly using it in my application.