### PR TITLE
Breaking change in react-native

### DIFF
--- a/RNMail/RNMail.h
+++ b/RNMail/RNMail.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface RNMail : NSObject <RCTBridgeModule, MFMailComposeViewControllerDelegate>
 


### PR DESCRIPTION
react-native 0.40 has a breaking change they have moved iOS native headers.

Please refer to https://github.com/facebook/react-native/releases/tag/v0.40.0