### PR TITLE
Create an index.js file and default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ public class MainApplication extends Application implements ReactApplication {
 
 ## Example
 ```javascript
-var Mailer = require('NativeModules').RNMail;
+var Mailer = require('react-native-mail');
 
 var MailExampleApp = React.createClass({
   handleHelp: function() {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+import { NativeModules } from 'react-native';
+
+export default NativeModules.RNMail;


### PR DESCRIPTION
With this change, consumers of this library will be able to just `import RNMail from 'react-native-mail'` instead of manually pulling the package from NativeModules. This will provide react-native-mail the same basic interface as other React Native Libraries