### PR TITLE
Fix iOS Plain Text Emails

### DIFF
--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -40,7 +40,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
         bool *isHTML = NO;
         
         if (options[@"isHTML"]){
-            isHTML = YES;
+            isHTML = [options[@"isHTML"] boolValue];
         }
 
         if (options[@"body"]){


### PR DESCRIPTION
The isHTML dictionary value is coming through as NCSFString. This PR sets isHTML value for NCSFBool with boolValue method.