### PR TITLE
Use the latest react native

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Please don't mind me if I am completely oblivious to the change I am making here.

Because `react-native-mail` is pointing to react-native `0.11.+` in my project we were compiling two version of `react-native` one the latest version and `react-native-mail` compiliing `0.11.0`. I understand this could be completely to do with my own project but this change fixes the issue for me.