### PR TITLE
Added the callback to detect email client closure

### DIFF
--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -31,9 +31,12 @@ public class RNMailModule extends ReactContextBaseJavaModule {
   private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
-      if (requestCode == MAIL_SEND_REQUEST) {
-          if(callback != null)
-            callback.invoke("mailclient_closed");
+      if (requestCode == MAIL_SEND_REQUEST && callback != null) {
+        try {
+            callback.invoke(null, "mailclient_closed");
+        } catch (Exception ex) {
+          //Lost the reference. don't do anything
+        }
       }
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-mail",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "description": "A wrapper on top of MFMailComposeViewController from iOS and Mail Intent on android",
   "author": {
     "name": "Chirag Jain",


### PR DESCRIPTION
If there is attachment in email client, client app might need to clean the attachment file once the user send the email. By adding this callback handler, client app can remove the attachment file once the user cancel/send the email client.