### PR TITLE
Add requiresMainQueueSetup

### DIFF
--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -21,6 +21,11 @@
     return dispatch_get_main_queue();
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(mail:(NSDictionary *)options


### PR DESCRIPTION
Added requiresMainQueueSetup to prevent warning and future side-effects in RNMail.