### PR TITLE
integrate with react-native-image-picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,23 @@
 A React Native wrapper for Apple's ``MFMailComposeViewController`` from iOS and Mail Intent on android
 Supports emails with attachments.
 
-### Installation
+## Installation
 
 There was a breaking change in RN >=40. So for React Native >= 0.40: use v3.x and higher of this lib. otherwise use v2.x
 
 ```bash
-npm i --save react-native-mail
+npm i --save react-native-mail # npm syntax
+yarn add react-native-mail # yarn syntax
 ```
 
-### Add it to your android project
+### Automatic Installation
+You can automatically link the native components or follow the manual instructions below if you prefer.
+
+ ```bash
+ react-native link
+ ```
+
+### Manual Installation: Android
 
 * In `android/setting.gradle`
 
@@ -85,7 +93,7 @@ public class MainApplication extends Application implements ReactApplication {
 
 
 
-### Add it to your iOS project
+### Manual Installation: iOS
 
 1. Run `npm install react-native-mail --save`
 2. Open your project in XCode, right click on `Libraries` and click `Add
@@ -97,16 +105,26 @@ public class MainApplication extends Application implements ReactApplication {
 
 ## Example
 ```javascript
-var Mailer = require('react-native-mail');
+/**
+ * Sample React Native App
+ * https://github.com/facebook/react-native
+ * @flow
+ */
 
-var MailExampleApp = React.createClass({
-  handleHelp: function() {
+import React, { Component } from 'react';
+import { View, Button } from 'react-native';
+import Mailer from 'react-native-mail';
+
+export default class App extends Component<{}> {
+
+  handleEmail = () => {
+    console.log(Mailer);
     Mailer.mail({
       subject: 'need help',
       recipients: ['support@example.com'],
       ccRecipients: ['supportCC@example.com'],
       bccRecipients: ['supportBCC@example.com'],
-      body: '',
+      body: '<b>A Bold Body</b>',
       isHTML: true,
       attachment: {
         path: '',  // The absolute path of the file from which to read data.
@@ -114,23 +132,34 @@ var MailExampleApp = React.createClass({
         name: '',   // Optional: Custom filename for attachment
       }
     }, (error, event) => {
-        if(error) {
-          AlertIOS.alert('Error', 'Could not send mail. Please send a mail to support@example.com');
-        }
+      console.log(error);
+      Alert.alert(
+        'Error',
+        'Email could not be sent',
+        [
+          {text: 'Ok', onPress: () => console.log('OK: Email Error Response')},
+          {text: 'Cancel', onPress: () => console.log('CANCEL: Email Error Response')}
+        ],
+        { cancelable: true }
+      )
     });
-  },  
-  render: function() {
+  }
+
+  render() {
     return (
-      <TouchableHighlight
-            onPress={row.handleHelp}
-            underlayColor="#f7f7f7">
-	      <View style={styles.container}>
-	        <Image source={require('image!announcement')} style={styles.image} />
-	      </View>
-	   </TouchableHighlight>
+      <View style={styles.container}>
+        <Button
+          onPress={this.handleEmail}
+          title="Email Me"
+          color="#841584"
+          accessabilityLabel="Purple Email Me Button"
+        />
+      </View>
     );
   }
-});
+}
+
+
 ```
 
 ### Note

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ public class MainApplication extends Application implements ReactApplication {
  */
 
 import React, { Component } from 'react';
-import { View, Button } from 'react-native';
+import { View, Alert, Button } from 'react-native';
 import Mailer from 'react-native-mail';
 
 export default class App extends Component {
@@ -131,7 +131,6 @@ export default class App extends Component {
         name: '',   // Optional: Custom filename for attachment
       }
     }, (error, event) => {
-      console.log(error);
       Alert.alert(
         'Error',
         'Email could not be sent',

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ export default class App extends Component {
       }
     }, (error, event) => {
       Alert.alert(
-        'Error',
-        'Email could not be sent',
+        error,
+        event,
         [
           {text: 'Ok', onPress: () => console.log('OK: Email Error Response')},
           {text: 'Cancel', onPress: () => console.log('CANCEL: Email Error Response')}

--- a/README.md
+++ b/README.md
@@ -115,10 +115,9 @@ import React, { Component } from 'react';
 import { View, Button } from 'react-native';
 import Mailer from 'react-native-mail';
 
-export default class App extends Component<{}> {
+export default class App extends Component {
 
   handleEmail = () => {
-    console.log(Mailer);
     Mailer.mail({
       subject: 'need help',
       recipients: ['support@example.com'],

--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -36,9 +36,9 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
             NSString *subject = [RCTConvert NSString:options[@"subject"]];
             [mail setSubject:subject];
         }
-        
+
         bool *isHTML = NO;
-        
+
         if (options[@"isHTML"]){
             isHTML = [options[@"isHTML"] boolValue];
         }
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
             NSArray *ccRecipients = [RCTConvert NSArray:options[@"ccRecipients"]];
             [mail setCcRecipients:ccRecipients];
         }
-        
+
         if (options[@"bccRecipients"]){
             NSArray *bccRecipients = [RCTConvert NSArray:options[@"bccRecipients"]];
             [mail setBccRecipients:bccRecipients];
@@ -73,12 +73,23 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
                 attachmentName = [[attachmentPath lastPathComponent] stringByDeletingPathExtension];
             }
 
+            // Get the URL string, which is *not* a path (e.g. because it's file:// based)
+            NSString *attachmentURLString = [RCTConvert NSString:options[@"attachment"][@"path"]];
+            // Create a URL from the string
+            NSURL *attachmentURL = [[NSURLComponents componentsWithString:attachmentURLString] URL];
+
             // Get the resource path and read the file using NSData
-            NSData *fileData = [NSData dataWithContentsOfFile:attachmentPath];
+            NSError *error = nil;
+            NSData *fileData = [NSData dataWithContentsOfURL:attachmentURL options:0 error:&error];
+
+            if(fileData == nil) {
+                // handle error
+            }
+
 
             // Determine the MIME type
             NSString *mimeType;
-            
+
             /*
              * Add additional mime types and PR if necessary. Find the list
              * of supported formats at http://www.iana.org/assignments/media-types/media-types.xhtml


### PR DESCRIPTION
The [react-native-image-picker](https://github.com/react-community/react-native-image-picker) library doesn't return the filePath URI that [react-native-mail](https://github.com/chirag04/react-native-mail) expects as the path to the attachment.

## For example, right now you expect
    // Android
    /storage/emulated/0/DCIM/Camera/IMG_20171102_11304344.jpg 

    // iOS
    /Users/anton/Library/Developer/CoreSimulator/Devices/9A15F203-9A58-41C5-A4FC-EA25FAAE92BD/data/Containers/Data/Application/79FF93F9-BA89-4F4C-8809-277BEECD447D/Documents/EFFF0ECE-4063-4FE5-984E-E76506788350.jpg

## But what image picker returns is more like this...

    file://var/mobile/Containers/Data/Application/983938D-5304-463C-BD05-D033E55F5BEB/Documents/images/224CA6DD-5299-48C3-A7CF-0B645004535F.jpg

## So what I've done is...

[Replace Line 82 of RNMail.m][1]

    NSData *fileData = [NSData dataWithContentsOfFile:attachmentPath];

With this code...

    // Get the URL string, which is *not* a path (e.g. because it's file:// based)
    NSString *attachmentURLString = [RCTConvert NSString:options[@"attachment"][@"path"]];
    // Create a URL from the string
    NSURL *attachmentURL = [[NSURLComponents componentsWithString:attachmentURLString] URL];

    // Get the resource path and read the file using NSData
    NSError *error = nil;
    NSData *fileData = [NSData dataWithContentsOfURL:attachmentURL options:0 error:&error];
    
    if(fileData == nil) {
        // handle error
    }

More information surrounding how this solution was arrived at, please see https://stackoverflow.com/questions/47170739/nsdata-assignment-vanishes-becomes-nil-directly-after-assigned#47170815


  [1]: https://github.com/chirag04/react-native-mail/blob/master/RNMail/RNMail.m#L82


