### PR TITLE
Multiple attachments

### DIFF
--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -113,18 +113,18 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
                         mimeType = @"application/zip";
                     } else if ([attachmentType isEqualToString:@"text"]) {
                         mimeType = @"text/*";
-            } else if ([attachmentType isEqualToString:@"mp3"]) {
-                mimeType = @"audio/mpeg";
-            } else if ([attachmentType isEqualToString:@"wav"]) {
-                mimeType = @"audio/wav";
-            } else if ([attachmentType isEqualToString:@"aiff"]) {
-                mimeType = @"audio/aiff";
-            } else if ([attachmentType isEqualToString:@"flac"]) {
-                mimeType = @"audio/flac";
-            } else if ([attachmentType isEqualToString:@"ogg"]) {
-                mimeType = @"audio/ogg";
-            } else if ([attachmentType isEqualToString:@"xls"]) {
-                mimeType = @"application/vnd.ms-excel";     
+                    } else if ([attachmentType isEqualToString:@"mp3"]) {
+                        mimeType = @"audio/mpeg";
+                    } else if ([attachmentType isEqualToString:@"wav"]) {
+                        mimeType = @"audio/wav";
+                    } else if ([attachmentType isEqualToString:@"aiff"]) {
+                        mimeType = @"audio/aiff";
+                    } else if ([attachmentType isEqualToString:@"flac"]) {
+                        mimeType = @"audio/flac";
+                    } else if ([attachmentType isEqualToString:@"ogg"]) {
+                        mimeType = @"audio/ogg";
+                    } else if ([attachmentType isEqualToString:@"xls"]) {
+                        mimeType = @"application/vnd.ms-excel";
                     }
                     [mail addAttachmentData:fileData mimeType:mimeType fileName:attachmentName];
                 }

--- a/RNMail/RNMail.m
+++ b/RNMail/RNMail.m
@@ -41,7 +41,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
             NSString *subject = [RCTConvert NSString:options[@"subject"]];
             [mail setSubject:subject];
         }
-        
+
         bool *isHTML = NO;
         
         if (options[@"isHTML"]){
@@ -57,7 +57,7 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
             NSArray *recipients = [RCTConvert NSArray:options[@"recipients"]];
             [mail setToRecipients:recipients];
         }
-
+        
         if (options[@"ccRecipients"]){
             NSArray *ccRecipients = [RCTConvert NSArray:options[@"ccRecipients"]];
             [mail setCcRecipients:ccRecipients];
@@ -67,49 +67,52 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
             NSArray *bccRecipients = [RCTConvert NSArray:options[@"bccRecipients"]];
             [mail setBccRecipients:bccRecipients];
         }
+        
+        if (options[@"attachments"]){
+            NSArray *attachments = [RCTConvert NSArray:options[@"attachments"]];
 
-        if (options[@"attachment"] && options[@"attachment"][@"path"] && options[@"attachment"][@"type"]){
-            NSString *attachmentPath = [RCTConvert NSString:options[@"attachment"][@"path"]];
-            NSString *attachmentType = [RCTConvert NSString:options[@"attachment"][@"type"]];
-            NSString *attachmentName = [RCTConvert NSString:options[@"attachment"][@"name"]];
+            for(NSDictionary *attachment in attachments) {
+                if (attachment[@"path"] && attachment[@"type"]) {
+                    NSString *attachmentPath = [RCTConvert NSString:attachment[@"path"]];
+                    NSString *attachmentType = [RCTConvert NSString:attachment[@"type"]];
+                    NSString *attachmentName = [RCTConvert NSString:attachment[@"name"]];
 
-            // Set default filename if not specificed
-            if (!attachmentName) {
-                attachmentName = [[attachmentPath lastPathComponent] stringByDeletingPathExtension];
-            }
+                    // Set default filename if not specificed
+                    if (!attachmentName) {
+                        attachmentName = [[attachmentPath lastPathComponent] stringByDeletingPathExtension];
+                    }
+                    // Get the resource path and read the file using NSData
+                    NSData *fileData = [NSData dataWithContentsOfFile:attachmentPath];
 
-            // Get the resource path and read the file using NSData
-            NSData *fileData = [NSData dataWithContentsOfFile:attachmentPath];
+                    // Determine the MIME type
+                    NSString *mimeType;
 
-            // Determine the MIME type
-            NSString *mimeType;
-            
-            /*
-             * Add additional mime types and PR if necessary. Find the list
-             * of supported formats at http://www.iana.org/assignments/media-types/media-types.xhtml
-             */
-            if ([attachmentType isEqualToString:@"jpg"]) {
-                mimeType = @"image/jpeg";
-            } else if ([attachmentType isEqualToString:@"png"]) {
-                mimeType = @"image/png";
-            } else if ([attachmentType isEqualToString:@"doc"]) {
-                mimeType = @"application/msword";
-            } else if ([attachmentType isEqualToString:@"ppt"]) {
-                mimeType = @"application/vnd.ms-powerpoint";
-            } else if ([attachmentType isEqualToString:@"html"]) {
-                mimeType = @"text/html";
-            } else if ([attachmentType isEqualToString:@"csv"]) {
-                mimeType = @"text/csv";
-            } else if ([attachmentType isEqualToString:@"pdf"]) {
-                mimeType = @"application/pdf";
-            } else if ([attachmentType isEqualToString:@"vcard"]) {
-                mimeType = @"text/vcard";
-            } else if ([attachmentType isEqualToString:@"json"]) {
-                mimeType = @"application/json";
-            } else if ([attachmentType isEqualToString:@"zip"]) {
-                mimeType = @"application/zip";
-            } else if ([attachmentType isEqualToString:@"text"]) {
-                mimeType = @"text/*";
+                    /*
+                     * Add additional mime types and PR if necessary. Find the list
+                     * of supported formats at http://www.iana.org/assignments/media-types/media-types.xhtml
+                     */
+                    if ([attachmentType isEqualToString:@"jpg"]) {
+                        mimeType = @"image/jpeg";
+                    } else if ([attachmentType isEqualToString:@"png"]) {
+                        mimeType = @"image/png";
+                    } else if ([attachmentType isEqualToString:@"doc"]) {
+                        mimeType = @"application/msword";
+                    } else if ([attachmentType isEqualToString:@"ppt"]) {
+                        mimeType = @"application/vnd.ms-powerpoint";
+                    } else if ([attachmentType isEqualToString:@"html"]) {
+                        mimeType = @"text/html";
+                    } else if ([attachmentType isEqualToString:@"csv"]) {
+                        mimeType = @"text/csv";
+                    } else if ([attachmentType isEqualToString:@"pdf"]) {
+                        mimeType = @"application/pdf";
+                    } else if ([attachmentType isEqualToString:@"vcard"]) {
+                        mimeType = @"text/vcard";
+                    } else if ([attachmentType isEqualToString:@"json"]) {
+                        mimeType = @"application/json";
+                    } else if ([attachmentType isEqualToString:@"zip"]) {
+                        mimeType = @"application/zip";
+                    } else if ([attachmentType isEqualToString:@"text"]) {
+                        mimeType = @"text/*";
             } else if ([attachmentType isEqualToString:@"mp3"]) {
                 mimeType = @"audio/mpeg";
             } else if ([attachmentType isEqualToString:@"wav"]) {
@@ -122,12 +125,12 @@ RCT_EXPORT_METHOD(mail:(NSDictionary *)options
                 mimeType = @"audio/ogg";
             } else if ([attachmentType isEqualToString:@"xls"]) {
                 mimeType = @"application/vnd.ms-excel";     
+                    }
+                    [mail addAttachmentData:fileData mimeType:mimeType fileName:attachmentName];
+                }
             }
-
-            // Add attachment
-            [mail addAttachmentData:fileData mimeType:mimeType fileName:attachmentName];
         }
-
+        
         UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
 
         while (root.presentedViewController) {

--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -66,32 +66,37 @@ public class RNMailModule extends ReactContextBaseJavaModule {
         i.putExtra(Intent.EXTRA_TEXT, Html.fromHtml(body));
       } else {
         i.putExtra(Intent.EXTRA_TEXT, body);
-      }
+    }
     }
 
     if (options.hasKey("recipients") && !options.isNull("recipients")) {
       ReadableArray recipients = options.getArray("recipients");
       i.putExtra(Intent.EXTRA_EMAIL, readableArrayToStringArray(recipients));
-    }
+      }
 
     if (options.hasKey("ccRecipients") && !options.isNull("ccRecipients")) {
       ReadableArray ccRecipients = options.getArray("ccRecipients");
       i.putExtra(Intent.EXTRA_CC, readableArrayToStringArray(ccRecipients));
     }
+    if (options.hasKey("attachments") && !options.isNull("attachments")) {
+      ReadableArray r = options.getArray("attachments");
+      int length = r.size();
+      ArrayList<Uri> uris = new ArrayList<Uri>();
+      for (int keyIndex = 0; keyIndex < length; keyIndex++) {
+        ReadableMap clip = r.getMap(keyIndex);
+        if (clip.hasKey("path") && !clip.isNull("path")){
+          String path = clip.getString("path");
+          File file = new File(path);
+          Uri u = Uri.fromFile(file);
+          uris.add(u);
+        }
+      }
+      i.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris);
+    }
 
     if (options.hasKey("bccRecipients") && !options.isNull("bccRecipients")) {
       ReadableArray bccRecipients = options.getArray("bccRecipients");
       i.putExtra(Intent.EXTRA_BCC, readableArrayToStringArray(bccRecipients));
-    }
-
-    if (options.hasKey("attachment") && !options.isNull("attachment")) {
-      ReadableMap attachment = options.getMap("attachment");
-      if (attachment.hasKey("path") && !attachment.isNull("path")) {
-        String path = attachment.getString("path");
-        File file = new File(path);
-        Uri p = Uri.fromFile(file);
-        i.putExtra(Intent.EXTRA_STREAM, p);
-      }
     }
 
     PackageManager manager = reactContext.getPackageManager();
@@ -110,14 +115,14 @@ public class RNMailModule extends ReactContextBaseJavaModule {
         callback.invoke("error");
       }
     } else {
-      Intent chooser = Intent.createChooser(i, "Send Mail");
-      chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    Intent chooser = Intent.createChooser(i, "Send Mail");
+    chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
-      try {
-        reactContext.startActivity(chooser);
-      } catch (Exception ex) {
-        callback.invoke("error");
-      }
+    try {
+      reactContext.startActivity(chooser);
+    } catch (Exception ex) {
+      callback.invoke("error");
     }
   }
+}
 }


### PR DESCRIPTION
Rebased #11 (the first PR for multiple attachments). Tested and working on iOS, and with Android changes from @kneza23

#### Breaking changes
`attachment:{}` is now `attachments:[]`, e.g.:
```js
Mailer.mail({
      subject: 'My email with attachments',
      recipients: [],
      body: 'Check this out',
      isHTML: true,
      attachments: [{
        path: this.imageFilePath,  // The absolute path of the file from which to read data.
        type: 'png',   // Mime Type: jpg, png, doc, ppt, html, pdf
      },{
        path: this.audioFilePath,
        type: 'wav',   
      }]
    }, (error, event) => {
      Alert.alert(
        error,
        event,
        [
          {text: 'OK', onPress: () => console.log('OK: Email Error Response')},
        ],
        { cancelable: true }
      )
    });

```
