### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ export default class App extends Component {
       isHTML: true,
       attachment: {
         path: '',  // The absolute path of the file from which to read data.
-        type: '',   // Mime Type: jpg, png, doc, ppt, html, pdf
+        type: '',   // Mime Type: jpg, png, doc, ppt, html, pdf, csv
         name: '',   // Optional: Custom filename for attachment
       }
     }, (error, event) => {


### PR DESCRIPTION
Added csv reference to mimetypes comment, considering the CSV mimetype has had a PR merged to allow it as an attached file format, and getting CSV data from an app, out to a spreadsheet, etc is a common feature in many apps.  I think it provides value having the label in the example snippet, as I certainly questioned whether or not CSV attachments were allowed when I seen a list of mimetypes in the comment, which did not include CSV.