### PR TITLE
fix tag notation to match repository tagging

### DIFF
--- a/react-native-mail.podspec
+++ b/react-native-mail.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license         = pjson["license"]
   s.author          = { "Chirag Jain" => "jain_chirag04@yahoo.com" }
   s.platform        = :ios, "7.0"
-  s.source          = { :git => "https://github.com/chirag04/react-native-mail", :tag => "#{s.version}" }
+  s.source          = { :git => "https://github.com/chirag04/react-native-mail", :tag => "v#{s.version}" }
   s.source_files    = 'RNMail/*.{h,m}'
   
   s.dependency 'React'


### PR DESCRIPTION
To support Cocoapods based installation on iOS I added the v before the tag name.
You should also tag release 3.0.6 to support latest version.