### PR TITLE
Workaround for Android Multiple Attachments bug

### DIFF
--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -98,7 +98,12 @@ public class RNMailModule extends ReactContextBaseJavaModule {
            uris.add(u);
          }
        }
-       i.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris);
+      
+       if (uris.size() == 1) {
+         i.putExtra(Intent.EXTRA_STREAM, uris.get(0));
+       } else {
+         i.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris);
+       }
      }
 
     PackageManager manager = reactContext.getPackageManager();


### PR DESCRIPTION
this workaround allows to send one attachment in the current v5. This allows users to update to v5 if they only need to send one attachment.