### PR TITLE
Add prop to change the title of IntentChooser on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ export default class App extends Component {
       ccRecipients: ['supportCC@example.com'],
       bccRecipients: ['supportBCC@example.com'],
       body: '<b>A Bold Body</b>',
+      customChooserTitle: "This is my new title", // Android only
       isHTML: true,
       attachments: [{
         path: '',  // The absolute path of the file from which to read data.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export default class App extends Component {
       ccRecipients: ['supportCC@example.com'],
       bccRecipients: ['supportBCC@example.com'],
       body: '<b>A Bold Body</b>',
-      customChooserTitle: "This is my new title", // Android only
+      customChooserTitle: "This is my new title", // Android only (defaults to "Send Mail")
       isHTML: true,
       attachments: [{
         path: '',  // The absolute path of the file from which to read data.

--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -117,7 +117,13 @@ public class RNMailModule extends ReactContextBaseJavaModule {
         callback.invoke("error");
       }
     } else {
-      Intent chooser = Intent.createChooser(i, "Send Mail");
+      String chooserTitle = "Send Mail";
+      
+      if (options.hasKey("customChooserTitle") && !options.isNull("customChooserTitle")) {
+        chooserTitle = options.getString("customChooserTitle");
+      } 
+      
+      Intent chooser = Intent.createChooser(i, chooserTitle);
       chooser.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
       try {


### PR DESCRIPTION
Added a prop called _customChooserTitle_ to allow users to set a custom title shown in the IntentChooser on Android. Added the usage to the readme stating its default value still being "Send Mail" as before.