### PR TITLE
Support multiple attachments on Android

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,4 +1,15 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.chirag.RNMail">
+  package="com.chirag.RNMail">
 
+  <application>
+    <provider
+        android:name=".RNMailFileProvider"
+        android:authorities="${applicationId}.rnmail.provider"
+        android:exported="false"
+        android:grantUriPermissions="true">
+        <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/provider_paths"/>
+    </provider>
+  </application>
 </manifest>

--- a/android/src/main/java/com/chirag/RNMail/RNMailFileProvider.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailFileProvider.java
@@ -1,0 +1,7 @@
+package com.chirag.RNMail;
+
+import androidx.core.content.FileProvider;
+
+public class RNMailFileProvider extends FileProvider {
+
+}

--- a/android/src/main/res/xml/provider_paths.xml
+++ b/android/src/main/res/xml/provider_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <external-path name="rnmail_dl" path="Download/" />
+    <cache-path name="rnmail_cache" path="/" />
+    <root-path name="rnmail_sdcard" path="." />
+</paths>


### PR DESCRIPTION
Fixes #153.

I've tested this in my app using my [patch](https://gist.github.com/grit96/3ec60fd657af831c8a5c61f9dd78c43a) via `patch-package` but haven't tested it properly standalone.

It uses `FileProvider` so might need to include some of #127.

Please can someone else test it too to make sure there's nothing else missing in this implementation?