### PR TITLE
Add index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,22 @@
+export namespace Mailer {
+  function mail(options: {
+    subject?: string;
+    recipients?: string[];
+    ccRecipients?: string[];
+    bccRecipients?: string[];
+    body?: string;
+    customChooserTitle?: string;
+    isHTML?: boolean;
+    attachments: {
+      path: string;
+      type?: string;
+      mimeType?: string;
+      name?: string;
+    }[]
+  }, callback: (
+    error: string,
+    event?: string
+  ) => void): void;
+}
+
+export default Mailer;


### PR DESCRIPTION
`index.d.ts` for typescript has been added by referring to the `android` and `ios` modules.
