### PR TITLE
Fix not_available issue when targetSdkVersion = 30

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.chirag.RNMail">
-
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.SEND_MULTIPLE" />
+      <data android:mimeType="*/*" />
+    </intent>
+  </queries>
   <application>
     <provider
         android:name=".RNMailFileProvider"


### PR DESCRIPTION
There are changes in Android 11 regarding how apps can query and interact with other apps https://developer.android.com/about/versions/11/privacy/package-visibility.

This was causing the `mail()` call to fail with `not_available` when targeting SDK 30. This PR fixes the issue by adding a `<queries>` element to `AndroidManifest.xml`.