### PR TITLE
minSdkVersion bump to prevent clashes with React Native 0.66.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 21
         targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
Fixes manifest merger error:

`Error: uses-sdk:minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-native:0.66.0]`