### PR TITLE
chore: make minSdkVersion configured based on default project property

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion project.hasProperty('buildToolsVersion') ? project.buildToolsVersion : "23.0.1"
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion project.hasProperty('minSdkVersion') ? project.minSdkVersion : 16
         targetSdkVersion project.hasProperty('targetSdkVersion') ? project.targetSdkVersion : 22
         versionCode 1
         versionName "1.0"


### PR DESCRIPTION
minSdkVersion 16 cannot be smaller than version 21 declared in library [com.facebook.react:react-android:0.72.4] 