### PR TITLE
Fix: Update build.gradle to use implementation instead of compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,30 @@ DerivedData
 *.xcuserstate
 project.xcworkspace
 
+
+# Node
+node_modules
+package-log.json
+*.log
+
+# Gradle
+/build/
+/RNTester/android/app/build/
+/RNTester/android/app/gradle/
+/RNTester/android/app/gradlew
+/RNTester/android/app/gradlew.bat
+/ReactAndroid/build/
+
+# Android/IntelliJ
+build/
+.idea
+.gradle
+local.properties
+*.iml
+*.hprof
+*.project
+
+
 # node.js
 #
 node_modules/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/com/chirag/RNMail/RNMailModule.java
+++ b/android/src/main/java/com/chirag/RNMail/RNMailModule.java
@@ -53,8 +53,14 @@ public class RNMailModule extends ReactContextBaseJavaModule {
 
   @ReactMethod
   public void mail(ReadableMap options, Callback callback) {
-    Intent i = new Intent(Intent.ACTION_SENDTO);
-    i.setData(Uri.parse("mailto:"));
+    Intent i;
+    if (options.hasKey("attachment") && !options.isNull("attachment")) {
+      i = new Intent(Intent.ACTION_SEND);
+      i.setType("vnd.android.cursor.dir/email");
+    } else {
+      i = new Intent(Intent.ACTION_SENDTO);
+      i.setData(Uri.parse("mailto:"));
+    }
 
     if (options.hasKey("subject") && !options.isNull("subject")) {
       i.putExtra(Intent.EXTRA_SUBJECT, options.getString("subject"));
@@ -63,7 +69,7 @@ public class RNMailModule extends ReactContextBaseJavaModule {
     if (options.hasKey("body") && !options.isNull("body")) {
       String body = options.getString("body");
       if (options.hasKey("isHTML") && options.getBoolean("isHTML")) {
-        i.putExtra(Intent.EXTRA_TEXT, Html.fromHtml(body));
+        i.putExtra(Intent.EXTRA_TEXT, Html.fromHtml(body).toString());
       } else {
         i.putExtra(Intent.EXTRA_TEXT, body);
       }


### PR DESCRIPTION
This fork is using an outdated Gradle DSL method (compile()), which has been deprecated since Gradle 3.0 and removed in Gradle 7.x. The modern equivalent is implementation() or api(), depending on the situation.

Since we are updating the Gradle version to 7+ in the install_garage_door repo, this fix is needed.